### PR TITLE
Update SSH.NET from 2020.0.2 to 2024.1.0. Breaking change due to major dependecy update

### DIFF
--- a/Frends.Community.Sftp/Definition.cs
+++ b/Frends.Community.Sftp/Definition.cs
@@ -117,7 +117,7 @@ namespace Frends.Community.Sftp
         public DateTime LastWriteTime { get; }
         public DateTime LastAccessTime { get; }
 
-        public FileResult(SftpFile file)
+        public FileResult(ISftpFile file)
         {
             this.FullPath = file.FullName;
             this.IsDirectory = file.IsDirectory;

--- a/Frends.Community.Sftp/Frends.Community.Sftp.csproj
+++ b/Frends.Community.Sftp/Frends.Community.Sftp.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
 	<TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
-    <authors>HiQ Finland</authors>
-    <copyright>HiQ Finland</copyright>
+    <authors>Frends</authors>
+    <copyright>Frends</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/CommunityHiQ/Frends.Community.Sftp</PackageProjectUrl>
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.1.2</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2024.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,14 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 
 # Change Log
 
-| Version | Changes |
-| ------- | ------- |
-| 1.0.0   | The initial version. |
-| 1.1.0   | DateTimes added to the result objects. |
-| 1.2.0   | Added Keyboard-interactive auth |
-| 1.3.0   | All possible auth combinations added (username, password, private key file, passphrase, keyboard interactive) |
-| 2.0.0   | Version number update to enable easier update from older sftp package. |
-| 2.1.0   | Added option to include subdirectories. |
-| 2.1.1   | Updated the dependency versions so the task would work with the new SFTP tasks and removed symbols from workflows. |
-| 2.1.2   | Fixed a bug with task iterating through . and .. directories over and over again. |
+| Version | Changes                                                                                                                                                                                  |
+|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.0  | The initial version.                                                                                                                                                                     |
+| 1.1.0  | DateTimes added to the result objects.                                                                                                                                                   |
+| 1.2.0  | Added Keyboard-interactive auth                                                                                                                                                          |
+| 1.3.0  | All possible auth combinations added (username, password, private key file, passphrase, keyboard interactive)                                                                            |
+| 2.0.0  | Version number update to enable easier update from older sftp package.                                                                                                                   |
+| 2.1.0  | Added option to include subdirectories.                                                                                                                                                  |
+| 2.1.1  | Updated the dependency versions so the task would work with the new SFTP tasks and removed symbols from workflows.                                                                       |
+| 2.1.2  | Fixed a bug with task iterating through . and .. directories over and over again.                                                                                                        |
+| 3.0.0  | Updated SSH.NET dependency from 2020.0.2 to 2024.1.0. Breaking change due to to several major version update. See SSH.NET version history at https://github.com/sshnet/SSH.NET/releases. |


### PR DESCRIPTION
#13 